### PR TITLE
Potential fix for code scanning alert no. 1: Disabling certificate validation

### DIFF
--- a/connector.js
+++ b/connector.js
@@ -1,6 +1,5 @@
 var fs = require('fs');
 var request = require('request');
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 process.env.VAULT_SKIP_VERIFY=true;
 var saToken = "";
 var saTokenFile = "";
@@ -102,7 +101,7 @@ async function getSecrets(vaultURL,vaultAcesssToken,vaultSecretMountpointPath){
 		url: vaultURL+vaultSecretMountpointPath,
 		method: 'GET',
 		followAllRedirects: true,
-		insecure: true,
+		strictSSL: true,
 		headers:{
 		  'Content-Type': 'application/json',
 		  'X-Vault-Token': vaultAcesssToken


### PR DESCRIPTION
Potential fix for [https://github.com/devops-genuine/va-autofix/security/code-scanning/1](https://github.com/devops-genuine/va-autofix/security/code-scanning/1)

To fix the problem, remove or conditionally set `process.env.NODE_TLS_REJECT_UNAUTHORIZED` so that certificate validation is not disabled by default. The best approach is to remove line 3 entirely, ensuring that Node.js performs proper certificate validation for all TLS connections. If there is a legitimate need to disable certificate validation for testing, this should be done via an environment variable or configuration, and never in production code. Additionally, review the use of the `insecure: true` option in the request options (line 105), as this may also disable certificate validation in some libraries; for the `request` library, the correct way to control certificate validation is via the `strictSSL` option (set to `true` by default). Remove or set `strictSSL: true` in the request options to ensure validation is enforced.

**Required changes:**
- Remove line 3: `process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";`
- In the `getSecrets` function, remove `insecure: true` from the request options (line 105).
- Optionally, add `strictSSL: true` to the request options to explicitly enforce certificate validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
